### PR TITLE
Add ESLint and package.json for npm scripts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+extension/webrtc_vad.js

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,13 @@
+env:
+  browser: true
+  es6: true
+  node: true
+
+extends:
+  - eslint:recommended
+
+rules:
+  eqeqeq: error
+  no-console: warn
+  no-unused-vars: [error, {vars: all, args: none, ignoreRestSiblings: false}]
+  no-warning-comments: warn

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+web-ext-artifacts

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "description": "This is a simple WebExtension that adds support to use Speech To Text as an input method in web pages.",
+  "name": "speak-to-me",
+  "version": "1.0.0",
+  "author": {
+    "name": "Fabrice Desré",
+    "url": "https://github.com/fabricedesre"
+  },
+  "bugs": {
+    "url": "https://github.com/fabricedesre/speaktome/issues"
+  },
+  "devDependencies": {
+    "eslint": "3.19.0",
+    "prettier": "1.2.2",
+    "web-ext": "1.9.0"
+  },
+  "homepage": "https://github.com/fabricedesre/speaktome#readme",
+  "keywords": [],
+  "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fabricedesre/speaktome.git"
+  },
+  "scripts": {
+    "build": "web-ext build -s extension",
+    "format:js": "prettier 'extension/content.js' --tab-width=4 --write",
+    "lint:extension": "web-ext lint -s extension",
+    "lint:js": "eslint extension",
+    "once": "web-ext run -s extension"
+  }
+}


### PR DESCRIPTION
Added 5 npm scripts:

- `npm run build` &mdash; Builds the web extension and saves it to web-ext default "web-ext-artifacts/" directory.
- `npm run format:js` &mdash; Formats the extension/content.js using [**prettier**](https://github.com/prettier/prettier).
- `npm run lint:extension` &mdash; Lints the web extension using web-ext.
- `npm run lint:js` &mdash; Lints the web extension using ESLint.
- `npm run once` &mdash; Launches Firefox w/ the extension enabled for local testing.
